### PR TITLE
fix(src): Invalidate cached partition table

### DIFF
--- a/src/drive-clean.cpp
+++ b/src/drive-clean.cpp
@@ -60,6 +60,17 @@ class AsyncWorker : public Nan::AsyncWorker {
       SetErrorMessage("Couldn't delete drive layout");
     }
 
+    // Invalidate the cached partition table and re-enumerate the device
+    BOOL updated = DeviceIoControl(
+      hDevice, IOCTL_DISK_UPDATE_PROPERTIES,
+      NULL, 0, NULL, 0, &size, NULL);
+
+    if (!updated) {
+      errorCode = GetLastError();
+      sysCall = "IOCTL_DISK_UPDATE_PROPERTIES";
+      SetErrorMessage("Couldn't flush drive changes");
+    }
+
     if (hDevice != INVALID_HANDLE_VALUE) {
       CloseHandle(hDevice);
     }


### PR DESCRIPTION
This adds a [IOCTL_DISK_UPDATE_PROPERTIES](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365192(v=vs.85).aspx) call to flush changes
to the device, and invalidate the system's cached partition table,
in order to ensure that the system won't reject writes to the raw device.

Change-Type: patch
Changelog-Entry: Invalidate cached partition table